### PR TITLE
feat: Refactor duels page and hooks for improved functionality

### DIFF
--- a/web/src/api/axios.api.ts
+++ b/web/src/api/axios.api.ts
@@ -50,6 +50,7 @@ export const APIRoutes = {
   GET_User_By_Id: (userId: string) => `/users/${userId}`,
   GET_User_Search: '/users/search',
   GET_User_By_Username: (username: string) => `/users/by-username/${username}`,
+  GET_Users_Presence: (ids: string) => `/users/presence?ids=${ids}`,
 
   // Friend API
   GET_Friends: '/friends',
@@ -57,6 +58,14 @@ export const APIRoutes = {
   POST_SEND_FRIEND_REQUEST: (friendId: number) => `/friends/${friendId}`,
   PATCH_ACCEPT_FRIEND_REQUEST: (friendId: number) => `/friends/${friendId}/accept`,
   PATCH_BLOCK_FRIEND: (friendId: number) => `/friends/${friendId}/block`,
+
+  // Duel API
+  POST_Challenge: (targetUserId: number) => `/duels/challenge/${targetUserId}`,
+  POST_AcceptChallenge: (challengeId: string) => `/duels/challenge/${challengeId}/accept`,
+  POST_DeclineChallenge: (challengeId: string) => `/duels/challenge/${challengeId}/decline`,
+  GET_PendingChallenges: '/duels/pending',
+  GET_DuelHistory: '/duels/history',
+  GET_DuelStats: '/duels/stats',
 
   // Course API
   GET_Subjects: '/get_subjects',

--- a/web/src/features/duels/components/ChallengeNotification.tsx
+++ b/web/src/features/duels/components/ChallengeNotification.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useDuel } from "@features/duels/context/DuelContext";
+import "@features/duels/styles/DuelsScreen.css";
+
+const ChallengeNotification: React.FC = () => {
+  const { pendingChallenge, acceptChallenge, declineChallenge } = useDuel();
+  const [timeLeft, setTimeLeft] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!pendingChallenge) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      setTimeLeft(0);
+      return;
+    }
+
+    setTimeLeft(pendingChallenge.expires_in);
+    intervalRef.current = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [pendingChallenge?.challenge_id]);
+
+  if (!pendingChallenge) return null;
+
+  return (
+    <div className="challenge-notif-banner">
+      <h4 className="challenge-notif-title">⚔️ Défi reçu !</h4>
+      <p className="challenge-notif-msg">
+        <strong>{pendingChallenge.from_username}</strong> te défie en duel !
+      </p>
+      <span className="challenge-notif-timer">
+        Expire dans {timeLeft}s
+      </span>
+      <div className="challenge-notif-actions">
+        <button className="challenge-accept-btn" onClick={acceptChallenge}>
+          ✅ Accepter
+        </button>
+        <button className="challenge-decline-btn" onClick={declineChallenge}>
+          ❌ Décliner
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChallengeNotification;

--- a/web/src/features/duels/components/DuelGame.tsx
+++ b/web/src/features/duels/components/DuelGame.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useDuel } from "@features/duels/context/DuelContext";
+import "@features/duels/styles/DuelsScreen.css";
+
+const QUESTIONS_PER_DUEL = 5;
+
+const DuelGame: React.FC = () => {
+  const {
+    currentQuestion,
+    myIdx,
+    lastResult,
+    endData,
+    answered,
+    screen,
+    sendAnswer,
+    goToLobby,
+  } = useDuel();
+
+  const [scores, setScores] = useState<{ [k: number]: number }>({ 0: 0, 1: 0 });
+  const [timeLeft, setTimeLeft] = useState(0);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [nextIn, setNextIn] = useState<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const nextIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Reset timer and selected answer on new question
+  useEffect(() => {
+    if (!currentQuestion) return;
+    setSelectedIdx(null);
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setTimeLeft(currentQuestion.time_limit);
+
+    intervalRef.current = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) { clearInterval(intervalRef.current!); return 0; }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [currentQuestion?.number]);
+
+  // Stop timer, update scores, start next-question countdown when result arrives
+  useEffect(() => {
+    if (!lastResult) {
+      if (nextIntervalRef.current) clearInterval(nextIntervalRef.current);
+      setNextIn(null);
+      return;
+    }
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setScores(lastResult.scores);
+
+    setNextIn(3);
+    nextIntervalRef.current = setInterval(() => {
+      setNextIn((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(nextIntervalRef.current!);
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => { if (nextIntervalRef.current) clearInterval(nextIntervalRef.current); };
+  }, [lastResult]);
+
+  const handleAnswer = (i: number) => {
+    if (answered) return;
+    setSelectedIdx(i);
+    sendAnswer(i);
+  };
+
+  // ── Bouton : classe + icône selon l'état ──────────────────────────────────
+  type BtnState = { cls: string; icon: string | null };
+
+  const getButtonState = (i: number): BtnState => {
+    // Phase résultat : montrer correct / faux / neutre atténué
+    if (lastResult) {
+      const isCorrect = i === lastResult.good_answer;
+      const isMyWrong = i === lastResult.my_answer && !isCorrect;
+      if (isCorrect) return { cls: "duel-answer-btn duel-answer-correct", icon: "✓" };
+      if (isMyWrong) return { cls: "duel-answer-btn duel-answer-wrong",   icon: "✗" };
+      return { cls: "duel-answer-btn duel-answer-dim", icon: null };
+    }
+
+    // Phase attente résultat : surbrillance de la réponse choisie
+    if (i === selectedIdx) return { cls: "duel-answer-btn duel-answer-selected", icon: null };
+
+    return { cls: "duel-answer-btn", icon: null };
+  };
+
+  // ── Message de statut ─────────────────────────────────────────────────────
+  const nextSuffix = nextIn !== null ? ` (prochaine dans ${nextIn}s)` : "";
+
+  const statusMsg = (() => {
+    if (!lastResult) {
+      return answered ? "✔ Réponse envoyée — en attente de l'adversaire..." : "";
+    }
+    if (lastResult.my_answer === null) {
+      return `⏱ Temps écoulé ! La bonne réponse était : « ${currentQuestion?.choices[lastResult.good_answer]} »${nextSuffix}`;
+    }
+    if (lastResult.my_answer === lastResult.good_answer) {
+      return `🎉 Bonne réponse !${nextSuffix}`;
+    }
+    return `❌ Mauvaise réponse — la bonne était : « ${currentQuestion?.choices[lastResult.good_answer]} »${nextSuffix}`;
+  })();
+
+  // ── Écran de fin ──────────────────────────────────────────────────────────
+  if (screen === "end" && endData && myIdx !== null) {
+    const myScore  = endData.scores[myIdx] ?? 0;
+    const oppScore = endData.scores[1 - myIdx] ?? 0;
+    const isDraw   = myScore === oppScore;
+    const isWin    = endData.winner === myIdx;
+
+    return (
+      <div className="duel-game-container">
+        <div className="duel-end-card">
+          <div className="duel-end-icon">{isDraw ? "🤝" : isWin ? "🏆" : "💀"}</div>
+          <div className="duel-end-msg">
+            {isDraw ? "Égalité !" : isWin ? "Tu as gagné !" : "Tu as perdu..."}
+          </div>
+          <div className="duel-scores">
+            <div className="duel-score-box">
+              <div className="duel-score-name">Toi</div>
+              <div className="duel-score-pts">{myScore}</div>
+            </div>
+            <div className="duel-score-box">
+              <div className="duel-score-name">Adversaire</div>
+              <div className="duel-score-pts">{oppScore}</div>
+            </div>
+          </div>
+          <button className="start-random-duel-btn" onClick={goToLobby}>
+            🔄 Rejouer
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Écran de jeu ──────────────────────────────────────────────────────────
+  if (!currentQuestion || myIdx === null) return null;
+
+  const totalTime = currentQuestion.time_limit;
+  const pct = (timeLeft / totalTime) * 100;
+  const barColor = pct > 40 ? "#f97316" : pct > 20 ? "#d97706" : "#b91c1c";
+
+  return (
+    <div className="duel-game-container">
+      <div className="duel-game-card">
+
+        {/* En-tête */}
+        <div className="duel-game-header">
+          <span className="duel-question-num">
+            Question {currentQuestion.number + 1} / {QUESTIONS_PER_DUEL}
+          </span>
+          <span className="duel-timer-text" style={{ color: barColor }}>
+            {timeLeft}s
+          </span>
+        </div>
+
+        {/* Barre timer */}
+        <div className="duel-timer-bar-wrap">
+          <div className="duel-timer-bar" style={{ width: `${pct}%`, background: barColor }} />
+        </div>
+
+        {/* Scores */}
+        <div className="duel-scores">
+          <div className="duel-score-box">
+            <div className="duel-score-name">Toi</div>
+            <div className="duel-score-pts">{scores[myIdx] ?? 0}</div>
+          </div>
+          <div className="duel-score-box">
+            <div className="duel-score-name">Adversaire</div>
+            <div className="duel-score-pts">{scores[1 - myIdx] ?? 0}</div>
+          </div>
+        </div>
+
+        {/* Question */}
+        <p className="duel-question-text">{currentQuestion.question}</p>
+
+        {/* Réponses */}
+        <div className="duel-answers-grid">
+          {currentQuestion.choices.map((choice, i) => {
+            const { cls, icon } = getButtonState(i);
+            return (
+              <button
+                key={i}
+                className={cls}
+                onClick={() => handleAnswer(i)}
+                disabled={answered || !!lastResult}
+              >
+                <span className="duel-answer-text">{choice}</span>
+                {icon && <span className="duel-answer-icon">{icon}</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Statut */}
+        {statusMsg && (
+          <div className={`duel-game-status ${lastResult ? (lastResult.my_answer === lastResult.good_answer ? "duel-status-correct" : "duel-status-wrong") : ""}`}>
+            {statusMsg}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DuelGame;

--- a/web/src/features/duels/components/DuelHistory.tsx
+++ b/web/src/features/duels/components/DuelHistory.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import type { DuelHistoryEntry } from "@shared/types/duels";
+import "@features/duels/styles/DuelsScreen.css";
+
+interface DuelHistoryProps {
+  history: DuelHistoryEntry[];
+  loading: boolean;
+}
+
+const OUTCOME_LABEL: Record<string, string> = {
+  win: "Victoire",
+  loss: "Défaite",
+  draw: "Égalité",
+};
+
+const OUTCOME_ICON: Record<string, string> = {
+  win: "🏆",
+  loss: "💀",
+  draw: "🤝",
+};
+
+function formatDate(raw: string | null): string {
+  if (!raw) return "—";
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+const DuelHistory: React.FC<DuelHistoryProps> = ({ history, loading }) => {
+  if (loading) {
+    return (
+      <div className="duel-stats-empty">
+        <div className="spinner" style={{ width: 32, height: 32, borderWidth: 3 }} />
+      </div>
+    );
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className="duel-stats-empty">
+        <p>Aucun duel terminé pour l'instant.</p>
+      </div>
+    );
+  }
+
+  // Most recent first
+  const sorted = [...history].sort(
+    (a, b) =>
+      new Date(b.played_at ?? 0).getTime() - new Date(a.played_at ?? 0).getTime()
+  );
+
+  return (
+    <div className="duel-history-list">
+      {sorted.map((entry) => (
+        <div key={entry.duel_id} className={`duel-history-row duel-history-${entry.outcome}`}>
+          <span className="duel-history-icon">{OUTCOME_ICON[entry.outcome]}</span>
+          <div className="duel-history-info">
+            <span className="duel-history-opponent">vs {entry.opponent_username}</span>
+            <span className="duel-history-date">{formatDate(entry.played_at)}</span>
+          </div>
+          <div className="duel-history-score">
+            <span className="duel-history-my-score">{entry.my_score}</span>
+            <span className="duel-history-sep">–</span>
+            <span className="duel-history-opp-score">{entry.opponent_score}</span>
+          </div>
+          <span className={`duel-history-badge duel-history-badge-${entry.outcome}`}>
+            {OUTCOME_LABEL[entry.outcome]}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DuelHistory;

--- a/web/src/features/duels/components/DuelStats.tsx
+++ b/web/src/features/duels/components/DuelStats.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import type { DuelStatsData } from "@shared/types/duels";
+import "@features/duels/styles/DuelsScreen.css";
+
+interface DuelStatsProps {
+  stats: DuelStatsData | null;
+  loading: boolean;
+}
+
+const DuelStats: React.FC<DuelStatsProps> = ({ stats, loading }) => {
+  if (loading) {
+    return (
+      <div className="duel-stats-empty">
+        <div className="spinner" style={{ width: 32, height: 32, borderWidth: 3 }} />
+      </div>
+    );
+  }
+
+  if (!stats || stats.total_games === 0) {
+    return (
+      <div className="duel-stats-empty">
+        <p>Aucune partie jouée pour l'instant. Lance ton premier duel !</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="duel-stats-container">
+      {/* Global counters */}
+      <div className="duel-stats-grid">
+        <div className="duel-stat-chip duel-stat-win">
+          <span className="duel-stat-icon">🏆</span>
+          <span className="duel-stat-value">{stats.wins}</span>
+          <span className="duel-stat-label">Victoires</span>
+        </div>
+        <div className="duel-stat-chip duel-stat-draw">
+          <span className="duel-stat-icon">🤝</span>
+          <span className="duel-stat-value">{stats.draws}</span>
+          <span className="duel-stat-label">Égalités</span>
+        </div>
+        <div className="duel-stat-chip duel-stat-loss">
+          <span className="duel-stat-icon">💀</span>
+          <span className="duel-stat-value">{stats.losses}</span>
+          <span className="duel-stat-label">Défaites</span>
+        </div>
+        <div className="duel-stat-chip duel-stat-total">
+          <span className="duel-stat-icon">⚔️</span>
+          <span className="duel-stat-value">{stats.total_games}</span>
+          <span className="duel-stat-label">Total</span>
+        </div>
+      </div>
+
+      {/* Winrate bar */}
+      <div className="duel-winrate-row">
+        <div className="duel-winrate-labels">
+          <span>Taux de victoire</span>
+          <span className="duel-winrate-pct">{stats.winrate}%</span>
+        </div>
+        <div className="duel-winrate-bar-wrap">
+          <div
+            className="duel-winrate-bar"
+            style={{ width: `${stats.winrate}%` }}
+          />
+        </div>
+        <div className="duel-avg-score">
+          Score moyen : <strong>{stats.avg_score}</strong> / 5
+        </div>
+      </div>
+
+      {/* Per-opponent breakdown */}
+      {stats.per_opponent.length > 0 && (
+        <div className="duel-per-opponent">
+          <h4 className="duel-per-opponent-title">Face à face</h4>
+          <div className="duel-opponent-list">
+            {stats.per_opponent
+              .sort((a, b) => b.wins + b.draws + b.losses - (a.wins + a.draws + a.losses))
+              .map((opp) => (
+                <div key={opp.opponent_id} className="duel-opponent-row">
+                  <span className="duel-opponent-name">{opp.opponent_username}</span>
+                  <div className="duel-opponent-record">
+                    <span className="rec-win">{opp.wins}V</span>
+                    <span className="rec-draw">{opp.draws}N</span>
+                    <span className="rec-loss">{opp.losses}D</span>
+                  </div>
+                  <span className="duel-opponent-winrate">{opp.winrate}%</span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DuelStats;

--- a/web/src/features/duels/components/FriendList.tsx
+++ b/web/src/features/duels/components/FriendList.tsx
@@ -1,60 +1,75 @@
 import React from "react";
 import type { Friend } from "@shared/types/duels";
-import "@features/duels/styles/DuelsScreen.css"; // We will create this next
+import "@features/duels/styles/DuelsScreen.css";
 
 interface FriendListProps {
-	friends: Friend[];
-	onDuelRequest: (friendId: string) => void;
+  friends: Friend[];
+  onDuelRequest: (friendId: string) => void;
+  loading?: boolean;
 }
 
-const FriendList: React.FC<FriendListProps> = ({ friends, onDuelRequest }) => {
-	return (
-		<div className="friend-list-container">
-			<h3 className="friend-list-title">Mes Amis</h3>
-			<div className="friend-list">
-				{friends.map((friend, index) => (
-					<div
-						key={friend.id}
-						className="friend-item"
-						style={
-							{
-								animationDelay: `${0.4 + index * 0.05}s`,
-							} as React.CSSProperties
-						}
-					>
-						<div className="friend-avatar-container">
-							{friend.avatarUrl ? (
-								<img
-									src={friend.avatarUrl}
-									alt={`${friend.firstName} ${friend.lastName}`}
-									className="friend-avatar"
-								/>
-							) : (
-								<div className="friend-avatar-placeholder">
-									{friend.firstName[0]}
-									{friend.lastName[0]}
-								</div>
-							)}
-							<span className={`friend-status ${friend.status}`}></span>
-						</div>
-						<div className="friend-info">
-							<span className="friend-name">
-								{friend.firstName} {friend.lastName}
-							</span>
-							<span className="friend-level">Niveau {friend.level}</span>
-						</div>
-						<button
-							className="duel-button"
-							onClick={() => onDuelRequest(friend.id)}
-							disabled={friend.status !== "online"}
-						>
-							⚔️ Duel
-						</button>
-					</div>
-				))}
-			</div>
-		</div>
-	);
+const FriendList: React.FC<FriendListProps> = ({
+  friends,
+  onDuelRequest,
+  loading,
+}) => {
+  return (
+    <div className="friend-list-container">
+      <h3 className="friend-list-title">Mes Amis</h3>
+      {loading ? (
+        <p style={{ color: "#94a3b8", fontSize: "0.9rem" }}>Chargement...</p>
+      ) : friends.length === 0 ? (
+        <p style={{ color: "#94a3b8", fontSize: "0.9rem" }}>
+          Aucun ami à afficher. Ajoute des amis pour les défier !
+        </p>
+      ) : (
+        <div className="friend-list">
+          {friends.map((friend, index) => (
+            <div
+              key={friend.id}
+              className="friend-item"
+              style={{ animationDelay: `${0.4 + index * 0.05}s` } as React.CSSProperties}
+            >
+              <div className="friend-avatar-container">
+                {friend.avatarUrl ? (
+                  <img
+                    src={friend.avatarUrl}
+                    alt={`${friend.firstName} ${friend.lastName}`}
+                    className="friend-avatar"
+                  />
+                ) : (
+                  <div className="friend-avatar-placeholder">
+                    {friend.firstName[0]}
+                    {friend.lastName[0]}
+                  </div>
+                )}
+                <span className={`friend-status ${friend.status}`} />
+              </div>
+              <div className="friend-info">
+                <span className="friend-name">
+                  {friend.firstName} {friend.lastName}
+                </span>
+                <span className={`friend-status-label friend-status-label-${friend.status}`}>
+                  {friend.status === "online"
+                    ? "En ligne"
+                    : friend.status === "in-game"
+                    ? "En partie"
+                    : "Hors ligne"}
+                </span>
+              </div>
+              <button
+                className="duel-button"
+                onClick={() => onDuelRequest(friend.id)}
+                disabled={friend.status === "offline"}
+              >
+                ⚔️ Duel
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default FriendList;

--- a/web/src/features/duels/components/LobbyToast.tsx
+++ b/web/src/features/duels/components/LobbyToast.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useRef } from "react";
+import { useDuel } from "@features/duels/context/DuelContext";
+import "@features/duels/styles/DuelsScreen.css";
+
+type ToastVariant = "success" | "error" | "warning" | "info";
+
+function detectVariant(msg: string): ToastVariant {
+  if (msg.startsWith("✅")) return "success";
+  if (msg.startsWith("❌")) return "error";
+  if (msg.startsWith("⚠️") || msg.startsWith("⏰")) return "warning";
+  return "info";
+}
+
+const LobbyToast: React.FC = () => {
+  const { lobbyStatus, setLobbyStatus } = useDuel();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!lobbyStatus) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setLobbyStatus(""), 5000);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [lobbyStatus, setLobbyStatus]);
+
+  if (!lobbyStatus) return null;
+
+  const variant = detectVariant(lobbyStatus);
+
+  return (
+    <div
+      className={`lobby-toast lobby-toast-${variant}`}
+      role="status"
+      onClick={() => setLobbyStatus("")}
+    >
+      <span className="lobby-toast-msg">{lobbyStatus}</span>
+      <button className="lobby-toast-close" aria-label="Fermer">✕</button>
+    </div>
+  );
+};
+
+export default LobbyToast;

--- a/web/src/features/duels/context/DuelContext.tsx
+++ b/web/src/features/duels/context/DuelContext.tsx
@@ -1,0 +1,323 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import APIAxios, { APIRoutes } from "@api/axios.api";
+import { useAuthStore } from "@shared/store/auth/auth.store";
+import type {
+  DuelEndData,
+  DuelLastResult,
+  DuelQuestion,
+  DuelScreen,
+  PendingChallenge,
+} from "@shared/types/duels";
+
+const WS_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string)
+  .replace(/^https/, "wss")
+  .replace(/^http/, "ws")
+  .replace(/\/$/, "");
+
+interface DuelContextValue {
+  screen: DuelScreen;
+  pendingChallenge: PendingChallenge | null;
+  currentQuestion: DuelQuestion | null;
+  myIdx: number | null;
+  lastResult: DuelLastResult | null;
+  endData: DuelEndData | null;
+  lobbyStatus: string;
+  waitingMessage: string;
+  answered: boolean;
+
+  startMatchmaking: () => void;
+  sendChallengeToUserId: (userId: number) => Promise<void>;
+  sendChallengeByUsername: (username: string) => Promise<void>;
+  acceptChallenge: () => Promise<void>;
+  declineChallenge: () => Promise<void>;
+  sendAnswer: (answerIdx: number) => void;
+  goToLobby: () => void;
+  setLobbyStatus: (msg: string) => void;
+}
+
+const DuelContext = createContext<DuelContextValue | null>(null);
+
+export const useDuel = () => {
+  const ctx = useContext(DuelContext);
+  if (!ctx) throw new Error("useDuel must be used within DuelProvider");
+  return ctx;
+};
+
+export const DuelProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const navigate = useNavigate();
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  const [screen, setScreen] = useState<DuelScreen>("lobby");
+  const [pendingChallenge, setPendingChallenge] =
+    useState<PendingChallenge | null>(null);
+  const [currentQuestion, setCurrentQuestion] = useState<DuelQuestion | null>(
+    null
+  );
+  const [myIdx, setMyIdx] = useState<number | null>(null);
+  const [lastResult, setLastResult] = useState<DuelLastResult | null>(null);
+  const [endData, setEndData] = useState<DuelEndData | null>(null);
+  const [lobbyStatus, setLobbyStatus] = useState("");
+  const [waitingMessage, setWaitingMessage] = useState(
+    "En attente d'un adversaire..."
+  );
+  const [answered, setAnswered] = useState(false);
+
+  const notifWsRef = useRef<WebSocket | null>(null);
+  const duelWsRef = useRef<WebSocket | null>(null);
+  const myAnswerRef = useRef<number | null>(null);
+  const currentQuestionRef = useRef<DuelQuestion | null>(null);
+  const answeredRef = useRef(false);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Duel WS ──────────────────────────────────────────────────────────────
+
+  const handleDuelMessage = useCallback((msg: Record<string, any>) => {
+    if (msg.type === "joined") {
+      setMyIdx(msg.player_idx);
+    } else if (msg.type === "error") {
+      setScreen("lobby");
+      setLobbyStatus("Erreur : " + msg.message);
+    } else if (msg.type === "question") {
+      myAnswerRef.current = null;
+      answeredRef.current = false;
+      setAnswered(false);
+      setLastResult(null);
+      const q: DuelQuestion = {
+        number: msg.number,
+        question: msg.question,
+        choices: msg.choices,
+        time_limit: msg.time_limit,
+      };
+      currentQuestionRef.current = q;
+      setCurrentQuestion(q);
+      setScreen("game");
+    } else if (msg.type === "result") {
+      setLastResult({
+        good_answer: msg.good_answer,
+        my_answer: myAnswerRef.current,
+        scores: msg.scores,
+      });
+    } else if (msg.type === "end") {
+      setEndData({ scores: msg.scores, winner: msg.winner });
+      setScreen("end");
+      duelWsRef.current?.close();
+      duelWsRef.current = null;
+    } else if (msg.type === "opponent_disconnected") {
+      setScreen("lobby");
+      setLobbyStatus("⚠️ Ton adversaire s'est déconnecté.");
+      duelWsRef.current?.close();
+      duelWsRef.current = null;
+    }
+  }, []);
+
+  const connectDuelWS = useCallback(
+    (roomId?: string | null) => {
+      duelWsRef.current?.close();
+      const token = useAuthStore.getState().accessToken;
+      const url = roomId
+        ? `${WS_BASE_URL}/ws/find_duel/?token=${token}&room_id=${roomId}`
+        : `${WS_BASE_URL}/ws/find_duel/?token=${token}`;
+      const ws = new WebSocket(url);
+      duelWsRef.current = ws;
+      ws.onmessage = (e) => handleDuelMessage(JSON.parse(e.data));
+      ws.onclose = (e) => {
+        if (e.code === 4001) {
+          setScreen("lobby");
+          setLobbyStatus("Session expirée, reconnecte-toi.");
+        }
+      };
+    },
+    [handleDuelMessage]
+  );
+
+  // ── Notification WS ───────────────────────────────────────────────────────
+
+  const connectNotifWS = useCallback(() => {
+    if (
+      notifWsRef.current?.readyState === WebSocket.OPEN ||
+      notifWsRef.current?.readyState === WebSocket.CONNECTING
+    )
+      return;
+
+    const token = useAuthStore.getState().accessToken;
+    if (!token) return;
+
+    const ws = new WebSocket(`${WS_BASE_URL}/ws/notifications/?token=${token}`);
+    notifWsRef.current = ws;
+
+    ws.onmessage = (e) => {
+      const msg: Record<string, any> = JSON.parse(e.data);
+      if (msg.type === "challenge_received") {
+        setPendingChallenge({
+          challenge_id: msg.challenge_id,
+          from_username: msg.from_username,
+          expires_in: msg.expires_in,
+        });
+      } else if (msg.type === "challenge_accepted") {
+        setPendingChallenge(null);
+        setLobbyStatus(`✅ ${msg.by_username} a accepté ! Connexion...`);
+        connectDuelWS(msg.room_id);
+        setWaitingMessage("Défi accepté, démarrage...");
+        setScreen("waiting");
+        navigate("/duels");
+      } else if (msg.type === "challenge_declined") {
+        setPendingChallenge(null);
+        setLobbyStatus(`❌ ${msg.by_username} a refusé ton défi.`);
+      } else if (msg.type === "challenge_expired") {
+        setPendingChallenge(null);
+        setLobbyStatus("⏰ Le défi a expiré.");
+      }
+    };
+
+    ws.onclose = () => {
+      const currentToken = useAuthStore.getState().accessToken;
+      if (currentToken) {
+        reconnectTimeoutRef.current = setTimeout(connectNotifWS, 3000);
+      }
+    };
+  }, [connectDuelWS, navigate]);
+
+  useEffect(() => {
+    if (accessToken) {
+      connectNotifWS();
+      checkPendingChallenges();
+    } else {
+      notifWsRef.current?.close();
+      notifWsRef.current = null;
+      duelWsRef.current?.close();
+      duelWsRef.current = null;
+      if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current);
+    }
+    return () => {
+      notifWsRef.current?.close();
+      duelWsRef.current?.close();
+      if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current);
+    };
+  }, [accessToken, connectNotifWS]);
+
+  const checkPendingChallenges = async () => {
+    try {
+      const r = await APIAxios.get(APIRoutes.GET_PendingChallenges);
+      const challenges: any[] = r.data;
+      if (challenges.length > 0) {
+        const c = challenges[challenges.length - 1];
+        setPendingChallenge({
+          challenge_id: c.challenge_id,
+          from_username: c.from_username,
+          expires_in: 60,
+        });
+      }
+    } catch {
+      // silencieux
+    }
+  };
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  const startMatchmaking = useCallback(() => {
+    setWaitingMessage("En attente d'un adversaire...");
+    setScreen("waiting");
+    navigate("/duels");
+    connectDuelWS(null);
+  }, [connectDuelWS, navigate]);
+
+  const sendChallengeToUserId = useCallback(async (userId: number) => {
+    await APIAxios.post(APIRoutes.POST_Challenge(userId));
+    setLobbyStatus("⏳ Défi envoyé, en attente de réponse...");
+  }, []);
+
+  const sendChallengeByUsername = useCallback(async (username: string) => {
+    setLobbyStatus("");
+    const r = await APIAxios.get(APIRoutes.GET_User_By_Username(username));
+    const target = r.data;
+    await APIAxios.post(APIRoutes.POST_Challenge(target.id));
+    setLobbyStatus(`⏳ Défi envoyé à ${username}, en attente de réponse...`);
+  }, []);
+
+  const acceptChallenge = useCallback(async () => {
+    if (!pendingChallenge) return;
+    const cid = pendingChallenge.challenge_id;
+    setPendingChallenge(null);
+    const r = await APIAxios.post(APIRoutes.POST_AcceptChallenge(cid));
+    const { room_id } = r.data;
+    connectDuelWS(room_id);
+    setWaitingMessage("Défi accepté, connexion...");
+    setScreen("waiting");
+    navigate("/duels");
+  }, [pendingChallenge, connectDuelWS, navigate]);
+
+  const declineChallenge = useCallback(async () => {
+    if (!pendingChallenge) return;
+    const cid = pendingChallenge.challenge_id;
+    setPendingChallenge(null);
+    await APIAxios.post(APIRoutes.POST_DeclineChallenge(cid));
+  }, [pendingChallenge]);
+
+  const sendAnswer = useCallback((answerIdx: number) => {
+    if (
+      answeredRef.current ||
+      !currentQuestionRef.current ||
+      !duelWsRef.current
+    )
+      return;
+    answeredRef.current = true;
+    myAnswerRef.current = answerIdx;
+    setAnswered(true);
+    duelWsRef.current.send(
+      JSON.stringify({
+        type: "answer",
+        number: currentQuestionRef.current.number,
+        answer: answerIdx,
+      })
+    );
+  }, []);
+
+  const goToLobby = useCallback(() => {
+    duelWsRef.current?.close();
+    duelWsRef.current = null;
+    setScreen("lobby");
+    setCurrentQuestion(null);
+    currentQuestionRef.current = null;
+    setEndData(null);
+    setLastResult(null);
+    setMyIdx(null);
+    setAnswered(false);
+    answeredRef.current = false;
+  }, []);
+
+  return (
+    <DuelContext.Provider
+      value={{
+        screen,
+        pendingChallenge,
+        currentQuestion,
+        myIdx,
+        lastResult,
+        endData,
+        lobbyStatus,
+        waitingMessage,
+        answered,
+        startMatchmaking,
+        sendChallengeToUserId,
+        sendChallengeByUsername,
+        acceptChallenge,
+        declineChallenge,
+        sendAnswer,
+        goToLobby,
+        setLobbyStatus,
+      }}
+    >
+      {children}
+    </DuelContext.Provider>
+  );
+};

--- a/web/src/features/duels/hooks/useDuelsPage.ts
+++ b/web/src/features/duels/hooks/useDuelsPage.ts
@@ -1,117 +1,148 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import type { Friend, Duel } from "@shared/types/duels";
+import { useState, useEffect, useCallback, useRef } from "react";
+import APIAxios, { APIRoutes } from "@api/axios.api";
+import { useDuel } from "@features/duels/context/DuelContext";
+import type { Friend, DuelHistoryEntry, DuelStatsData } from "@shared/types/duels";
+import type { Friend as ApiFriend } from "@features/friends/store/friend.model";
+
+const PRESENCE_POLL_INTERVAL = 10_000;
 
 export const useDuelsScreen = () => {
-	const navigate = useNavigate();
+  const duel = useDuel();
 
-	const [friends, setFriends] = useState<Friend[]>([]);
-	const [activeDuels, setActiveDuels] = useState<Duel[]>([]);
-	const [isSearching, setIsSearching] = useState(false);
+  const [friends, setFriends] = useState<Friend[]>([]);
+  const [loadingFriends, setLoadingFriends] = useState(false);
 
-	useEffect(() => {
-		const mockFriends: Friend[] = [
-			{
-				id: "1",
-				firstName: "Alice",
-				lastName: "Kate",
-				level: 5,
-				status: "online",
-			},
-			{
-				id: "2",
-				firstName: "Bob",
-				lastName: "Bardy",
-				level: 3,
-				status: "offline",
-			},
-			{
-				id: "3",
-				firstName: "Charlie",
-				lastName: "Stark",
-				level: 7,
-				status: "in-game",
-			},
-			{
-				id: "4",
-				firstName: "David",
-				lastName: "Williams",
-				level: 2,
-				status: "online",
-			},
-		];
-		setFriends(mockFriends);
+  const [history, setHistory] = useState<DuelHistoryEntry[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(false);
 
-		const mockDuels: Duel[] = [
-			// { id: 'd1', opponent: mockFriends[0], status: 'pending', type: 'friend' }
-		];
-		setActiveDuels(mockDuels);
-	}, []);
+  const [stats, setStats] = useState<DuelStatsData | null>(null);
+  const [loadingStats, setLoadingStats] = useState(false);
 
-	const handleNavigation = (page: string) => {
-		switch (page) {
-			case "Accueil":
-				navigate("/home");
-				break;
-			case "Cours":
-				navigate("/courses");
-				break;
-			case "Missions":
-				navigate("/missions");
-				break;
-			case "Duels":
-				navigate("/duels");
-				break;
-			case "Profil":
-				navigate("/profile");
-				break;
-			default:
-				navigate("/home");
-		}
-	};
+  // Keep friend IDs in a ref so the presence poller always has fresh IDs
+  // without needing to be re-registered as a dependency.
+  const friendIdsRef = useRef<string[]>([]);
 
-	const handleDuelRequest = (friendId: string) => {
-		// Mock adding a pending duel
-		const friend = friends.find((f) => f.id === friendId);
-		if (friend) {
-			const newDuel: Duel = {
-				id: `d-${Date.now()}`,
-				opponent: friend,
-				status: "pending",
-				type: "friend",
-			};
-			setActiveDuels([...activeDuels, newDuel]);
-		}
-	};
+  // ── Load accepted friends ─────────────────────────────────────────────────
+  useEffect(() => {
+    setLoadingFriends(true);
+    APIAxios.get(APIRoutes.GET_Friends)
+      .then((r) => {
+        const accepted: ApiFriend[] = r.data.filter(
+          (f: ApiFriend) => f.status === "accepted"
+        );
+        const mapped: Friend[] = accepted.map((f) => ({
+          // direction='sent'   → je suis user_id, l'ami est friend_id
+          // direction='received' → l'ami est user_id, je suis friend_id
+          id: String(f.direction === "received" ? f.user_id : f.friend_id),
+          firstName: f.friend_first_name,
+          lastName: f.friend_last_name,
+          level: 0,
+          status: "offline" as const,
+        }));
+        setFriends(mapped);
+        friendIdsRef.current = mapped.map((f) => f.id);
+        pollPresence();
+      })
+      .catch(() => setFriends([]))
+      .finally(() => setLoadingFriends(false));
+  }, []);
 
-	const handleRandomDuel = () => {
-		setIsSearching(true);
-		// Mock search delay
-		setTimeout(() => {
-			setIsSearching(false);
-			const randomOpponent: Friend = {
-				id: "r1",
-				firstName: "Random",
-				lastName: "Player",
-				level: 4,
-				status: "online",
-			};
-			const newDuel: Duel = {
-				id: `d-${Date.now()}`,
-				opponent: randomOpponent,
-				status: "active",
-				type: "random",
-			};
-			setActiveDuels([...activeDuels, newDuel]);
-		}, 2000);
-	};
+  // ── Presence polling ──────────────────────────────────────────────────────
+  const pollPresence = useCallback(async () => {
+    const ids = friendIdsRef.current;
+    console.log("[Presence] poll — IDs:", ids);
+    if (ids.length === 0) {
+      console.log("[Presence] aucun ami, skip");
+      return;
+    }
+    try {
+      const r = await APIAxios.get(APIRoutes.GET_Users_Presence(ids.join(",")));
+      console.log("[Presence] réponse backend:", r.data);
+      const presence: Record<string, "online" | "in-game" | "offline"> = r.data;
+      setFriends((prev) =>
+        prev.map((f) => ({
+          ...f,
+          status: presence[f.id] ?? "offline",
+        }))
+      );
+    } catch (err) {
+      console.error("[Presence] erreur requête:", err);
+    }
+  }, []);
 
-	return {
-		friends,
-		activeDuels,
-		isSearching,
-		handleNavigation,
-		handleDuelRequest,
-		handleRandomDuel,
-	};
+  useEffect(() => {
+    console.log("[Presence] intervalle démarré");
+    let interval: ReturnType<typeof setInterval> | null = setInterval(
+      pollPresence,
+      PRESENCE_POLL_INTERVAL
+    );
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        console.log("[Presence] onglet caché — pause");
+        if (interval) { clearInterval(interval); interval = null; }
+      } else {
+        console.log("[Presence] onglet visible — reprise");
+        pollPresence();
+        interval = setInterval(pollPresence, PRESENCE_POLL_INTERVAL);
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      console.log("[Presence] intervalle nettoyé");
+      if (interval) clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [pollPresence]);
+
+  // ── Load history & stats ──────────────────────────────────────────────────
+  const fetchHistory = useCallback(() => {
+    setLoadingHistory(true);
+    APIAxios.get(APIRoutes.GET_DuelHistory)
+      .then((r) => setHistory(r.data))
+      .catch(() => setHistory([]))
+      .finally(() => setLoadingHistory(false));
+  }, []);
+
+  const fetchStats = useCallback(() => {
+    setLoadingStats(true);
+    APIAxios.get(APIRoutes.GET_DuelStats)
+      .then((r) => setStats(r.data))
+      .catch(() => setStats(null))
+      .finally(() => setLoadingStats(false));
+  }, []);
+
+  useEffect(() => {
+    fetchHistory();
+    fetchStats();
+  }, [fetchHistory, fetchStats]);
+
+  // Refresh history and stats after a game ends
+  useEffect(() => {
+    if (duel.screen === "end") {
+      fetchHistory();
+      fetchStats();
+    }
+  }, [duel.screen, fetchHistory, fetchStats]);
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+  const handleDuelRequest = async (friendId: string) => {
+    try {
+      await duel.sendChallengeToUserId(Number(friendId));
+    } catch {
+      duel.setLobbyStatus("❌ Impossible d'envoyer le défi.");
+    }
+  };
+
+  return {
+    friends,
+    loadingFriends,
+    history,
+    loadingHistory,
+    stats,
+    loadingStats,
+    handleDuelRequest,
+    ...duel,
+  };
 };

--- a/web/src/features/duels/pages/Duels.page.tsx
+++ b/web/src/features/duels/pages/Duels.page.tsx
@@ -2,93 +2,121 @@ import React from "react";
 import { useDuelsScreen } from "@features/duels/hooks/useDuelsPage";
 import FriendList from "@features/duels/components/FriendList";
 import DuelCard from "@features/duels/components/DuelCard";
+import DuelGame from "@features/duels/components/DuelGame";
+import DuelStats from "@features/duels/components/DuelStats";
+import DuelHistory from "@features/duels/components/DuelHistory";
+import LobbyToast from "@features/duels/components/LobbyToast";
 import ScreenLayout from "@shared/components/ScreenLayout.component";
 import "@features/duels/styles/DuelsScreen.css";
 
 const DuelsScreen: React.FC = () => {
-	const {
-		friends,
-		activeDuels,
-		isSearching,
-		handleDuelRequest,
-		handleRandomDuel,
-	} = useDuelsScreen();
+  const {
+    friends,
+    loadingFriends,
+    history,
+    loadingHistory,
+    stats,
+    loadingStats,
+    handleDuelRequest,
+    screen,
+    startMatchmaking,
+    waitingMessage,
+    goToLobby,
+  } = useDuelsScreen();
 
-	return (
-		<>
-			<ScreenLayout>
-				<div className="duels-page-container">
-					{/* Welcome Banner */}
-					<section className="duels-welcome-card">
-						<div className="duels-welcome-milo-image-container">
-							<img
-								src="/buttonGo.webp"
-								alt="Milo greetings"
-								className="milo-greeting-image"
-							/>
-						</div>
-						<div className="duels-welcome-text">
-							<h1 className="welcome-card-title">Arène de Duels</h1>
-							<p className="welcome-card-subtitle">
-								Défie tes amis ou affronte des adversaires aléatoires pour
-								monter dans le classement !
-							</p>
-						</div>
-					</section>
+  // ── Game / End screens (full takeover) ────────────────────────────────────
+  if (screen === "game" || screen === "end") {
+    return (
+      <ScreenLayout>
+        <DuelGame />
+      </ScreenLayout>
+    );
+  }
 
-					<div className="duels-top-row">
-						{/* Active Duels / Random Duel Section */}
-						<section className="duels-section-card">
-							<div className="section-header">
-								<h2 className="section-title">⚔️ Duels</h2>
-							</div>
+  // ── Waiting screen ────────────────────────────────────────────────────────
+  if (screen === "waiting") {
+    return (
+      <ScreenLayout>
+        <div className="duel-game-container">
+          <div className="duel-game-card" style={{ textAlign: "center", gap: "24px" }}>
+            <div className="spinner" style={{ margin: "0 auto" }} />
+            <h2 style={{ color: "#f97316", fontWeight: 700 }}>⏳ En attente...</h2>
+            <p style={{ color: "#64748b" }}>{waitingMessage}</p>
+            <button className="challenge-decline-btn" onClick={goToLobby}>
+              Annuler
+            </button>
+          </div>
+        </div>
+      </ScreenLayout>
+    );
+  }
 
-							<div
-								style={{
-									display: "flex",
-									flexDirection: "column",
-									gap: "20px",
-								}}
-							>
-								{activeDuels.length > 0 ? (
-									activeDuels.map((duel, index) => (
-										<DuelCard
-											key={duel.id}
-											duel={duel}
-											animationDelay={`${0.4 + index * 0.1}s`}
-										/>
-									))
-								) : (
-									<DuelCard
-										isSearching={isSearching}
-										onRandomDuel={handleRandomDuel}
-										animationDelay="0.4s"
-									/>
-								)}
-							</div>
-						</section>
+  // ── Lobby ─────────────────────────────────────────────────────────────────
+  return (
+    <ScreenLayout>
+      <div className="duels-page-container">
+        {/* Welcome Banner */}
+        <section className="duels-welcome-card">
+          <div className="duels-welcome-milo-image-container">
+            <img
+              src="/buttonGo.webp"
+              alt="Milo greetings"
+              className="milo-greeting-image"
+            />
+          </div>
+          <div className="duels-welcome-text">
+            <h1 className="welcome-card-title">Arène de Duels</h1>
+            <p className="welcome-card-subtitle">
+              Défie tes amis ou affronte des adversaires aléatoires pour
+              monter dans le classement !
+            </p>
+          </div>
+        </section>
 
-						{/* Friends List Section */}
-						<section className="duels-section-card">
-							<FriendList friends={friends} onDuelRequest={handleDuelRequest} />
-						</section>
-					</div>
+        <LobbyToast />
 
-					{/* History or Leaderboard could go here */}
-					<section className="duels-section-card">
-						<div className="section-header">
-							<h2 className="section-title">🏆 Classement Hebdomadaire</h2>
-						</div>
-						<div
-							style={{ textAlign: "center", padding: "20px", color: "#64748b" }}
-						>
-							<p>Le classement sera bientôt disponible !</p>
-						</div>
-					</section>
-				</div>
-			</ScreenLayout>
-		</>
-	);
+        <div className="duels-top-row">
+          {/* Duel actions */}
+          <section className="duels-section-card">
+            <div className="section-header">
+              <h2 className="section-title">⚔️ Duels</h2>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+              {/* Random matchmaking card */}
+              <DuelCard onRandomDuel={startMatchmaking} animationDelay="0.4s" />
+
+              {/* Challenge a friend by username */}
+            </div>
+          </section>
+
+          {/* Friends list */}
+          <section className="duels-section-card">
+            <FriendList
+              friends={friends}
+              onDuelRequest={handleDuelRequest}
+              loading={loadingFriends}
+            />
+          </section>
+        </div>
+
+        {/* Stats */}
+        <section className="duels-section-card">
+          <div className="section-header">
+            <h2 className="section-title">📊 Mes Statistiques</h2>
+          </div>
+          <DuelStats stats={stats} loading={loadingStats} />
+        </section>
+
+        {/* History */}
+        <section className="duels-section-card">
+          <div className="section-header">
+            <h2 className="section-title">📜 Historique des parties</h2>
+          </div>
+          <DuelHistory history={history} loading={loadingHistory} />
+        </section>
+      </div>
+    </ScreenLayout>
+  );
 };
 
 export default DuelsScreen;

--- a/web/src/features/duels/styles/DuelsScreen.css
+++ b/web/src/features/duels/styles/DuelsScreen.css
@@ -249,6 +249,15 @@
   color: #64748b;
 }
 
+.friend-status-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.friend-status-label-online  { color: #16a34a; }
+.friend-status-label-in-game { color: #ca8a04; }
+.friend-status-label-offline { color: #94a3b8; }
+
 .duel-button {
   padding: 8px 16px;
   background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
@@ -422,3 +431,657 @@
     transform: rotate(360deg);
   }
 }
+
+/* ── Lobby Toast ─────────────────────────────────────────────────────────── */
+
+.lobby-toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  border-radius: 16px;
+  border: 1.5px solid transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  animation: toastIn 0.25s ease-out forwards;
+  cursor: pointer;
+}
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.lobby-toast-success {
+  background: #f0fdf4;
+  border-color: #86efac;
+  color: #15803d;
+}
+
+.lobby-toast-error {
+  background: #fef2f2;
+  border-color: #fca5a5;
+  color: #b91c1c;
+}
+
+.lobby-toast-warning {
+  background: #fffbeb;
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
+.lobby-toast-info {
+  background: #fff7ed;
+  border-color: #fdba74;
+  color: #c2410c;
+}
+
+.lobby-toast-msg {
+  flex: 1;
+}
+
+.lobby-toast-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  opacity: 0.5;
+  padding: 0 2px;
+  color: inherit;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.lobby-toast-close:hover { opacity: 1; }
+
+/* ── Challenge Notification Banner ──────────────────────────────────────── */
+
+.challenge-notif-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: white;
+  border: 2px solid #f97316;
+  border-radius: 16px;
+  padding: 16px 20px;
+  width: 90%;
+  max-width: 420px;
+  z-index: 1000;
+  box-shadow: 0 8px 32px rgba(249, 115, 22, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  animation: fadeInUp 0.3s ease-out forwards;
+}
+
+.challenge-notif-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f97316;
+  margin: 0;
+}
+
+.challenge-notif-msg {
+  color: #1e293b;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.challenge-notif-timer {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.challenge-notif-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.challenge-accept-btn,
+.challenge-decline-btn {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: opacity 0.15s;
+}
+
+.challenge-accept-btn {
+  background: linear-gradient(135deg, #16a34a, #15803d);
+  color: white;
+}
+
+.challenge-decline-btn {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.challenge-accept-btn:hover,
+.challenge-decline-btn:hover {
+  opacity: 0.85;
+}
+
+/* ── Challenge Friend Input ──────────────────────────────────────────────── */
+
+.challenge-friend-container {
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid #e2e8f0;
+}
+
+.challenge-friend-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #475569;
+  margin: 0;
+}
+
+.challenge-friend-row {
+  display: flex;
+  gap: 8px;
+}
+
+.challenge-friend-input {
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  color: #1e293b;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.challenge-friend-input:focus {
+  border-color: #f97316;
+}
+
+.challenge-friend-btn {
+  padding: 10px 18px;
+  background: linear-gradient(135deg, #ff6b35 0%, #ea580c 100%);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.challenge-friend-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(255, 107, 53, 0.3);
+}
+
+.challenge-friend-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.challenge-friend-error {
+  color: #b91c1c;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.challenge-friend-status {
+  color: #64748b;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+/* ── Duel Game Screen ────────────────────────────────────────────────────── */
+
+.duel-game-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 120px);
+  padding: 20px;
+}
+
+.duel-game-card {
+  background: white;
+  border-radius: 24px;
+  padding: 28px;
+  width: 100%;
+  max-width: 520px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border: 1px solid #e2e8f0;
+}
+
+.duel-game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.duel-question-num {
+  font-size: 0.9rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.duel-timer-text {
+  font-size: 1.2rem;
+  font-weight: 800;
+  transition: color 0.3s;
+}
+
+.duel-timer-bar-wrap {
+  background: #f1f5f9;
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+}
+
+.duel-timer-bar {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.9s linear, background 0.3s;
+}
+
+.duel-scores {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.duel-score-box {
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 14px 28px;
+  text-align: center;
+  border: 1px solid #e2e8f0;
+  flex: 1;
+}
+
+.duel-score-name {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-bottom: 4px;
+}
+
+.duel-score-pts {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #ff6b35, #f97316);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.duel-question-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.duel-answers-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.duel-answer-btn {
+  padding: 14px 10px;
+  background: #f8fafc;
+  color: #1e293b;
+  border: 2px solid #e2e8f0;
+  border-radius: 14px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.18s;
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.duel-answer-btn:hover:not(:disabled) {
+  border-color: #f97316;
+  background: #fff7ed;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(249,115,22,0.15);
+}
+
+.duel-answer-btn:disabled {
+  cursor: not-allowed;
+}
+
+/* Réponse sélectionnée en attente du résultat */
+.duel-answer-btn.duel-answer-selected {
+  border-color: #f97316;
+  background: #fff7ed;
+  color: #c2410c;
+  font-weight: 700;
+  box-shadow: 0 0 0 3px rgba(249,115,22,0.2);
+}
+
+/* Bonne réponse */
+.duel-answer-btn.duel-answer-correct {
+  border-color: #16a34a;
+  background: #f0fdf4;
+  color: #15803d;
+  font-weight: 700;
+  box-shadow: 0 0 0 3px rgba(22,163,74,0.15);
+}
+
+/* Mauvaise réponse de l'utilisateur */
+.duel-answer-btn.duel-answer-wrong {
+  border-color: #b91c1c;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-weight: 700;
+  box-shadow: 0 0 0 3px rgba(185,28,28,0.12);
+}
+
+/* Autres réponses atténuées après résultat */
+.duel-answer-btn.duel-answer-dim {
+  opacity: 0.4;
+}
+
+.duel-answer-text {
+  flex: 1;
+}
+
+.duel-answer-icon {
+  font-size: 1.1rem;
+  font-weight: 800;
+  flex-shrink: 0;
+}
+
+.duel-game-status {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #64748b;
+  min-height: 20px;
+  transition: all 0.2s;
+}
+
+.duel-game-status.duel-status-correct {
+  background: #f0fdf4;
+  color: #15803d;
+}
+
+.duel-game-status.duel-status-wrong {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+/* ── Duel End Screen ─────────────────────────────────────────────────────── */
+
+.duel-end-card {
+  background: white;
+  border-radius: 24px;
+  padding: 40px 28px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  border: 1px solid #e2e8f0;
+  text-align: center;
+}
+
+.duel-end-icon {
+  font-size: 4.5rem;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15));
+}
+
+.duel-end-msg {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #1e293b;
+}
+
+/* ── Duel Stats ──────────────────────────────────────────────────────────── */
+
+.duel-stats-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  min-height: 80px;
+}
+
+.duel-stats-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.duel-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 600px) {
+  .duel-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.duel-stat-chip {
+  border-radius: 16px;
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.duel-stat-win  { background: #f0fdf4; border-color: #bbf7d0; }
+.duel-stat-draw { background: #fffbeb; border-color: #fde68a; }
+.duel-stat-loss { background: #fef2f2; border-color: #fecaca; }
+.duel-stat-total { background: #f8fafc; border-color: #e2e8f0; }
+
+.duel-stat-icon  { font-size: 1.5rem; }
+.duel-stat-value {
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: #1e293b;
+  line-height: 1;
+}
+.duel-stat-label {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.duel-winrate-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.duel-winrate-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.duel-winrate-pct {
+  color: #f97316;
+  font-weight: 800;
+}
+
+.duel-winrate-bar-wrap {
+  background: #f1f5f9;
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.duel-winrate-bar {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ff6b35, #f97316);
+  transition: width 0.6s ease;
+}
+
+.duel-avg-score {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.duel-per-opponent {
+  border-top: 1px solid #f1f5f9;
+  padding-top: 16px;
+}
+
+.duel-per-opponent-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #475569;
+  margin: 0 0 12px 0;
+}
+
+.duel-opponent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.duel-opponent-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: #f8fafc;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.duel-opponent-name {
+  flex: 1;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.duel-opponent-record {
+  display: flex;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.rec-win  { color: #16a34a; }
+.rec-draw { color: #ca8a04; }
+.rec-loss { color: #b91c1c; }
+
+.duel-opponent-winrate {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #f97316;
+  min-width: 36px;
+  text-align: right;
+}
+
+/* ── Duel History ────────────────────────────────────────────────────────── */
+
+.duel-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 400px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.duel-history-list::-webkit-scrollbar {
+  width: 6px;
+}
+.duel-history-list::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 3px; }
+.duel-history-list::-webkit-scrollbar-thumb { background: #fed7aa; border-radius: 3px; }
+
+.duel-history-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  transition: transform 0.15s;
+}
+
+.duel-history-row:hover { transform: translateX(3px); }
+
+.duel-history-win  { background: #f0fdf4; border-color: #bbf7d0; }
+.duel-history-loss { background: #fef2f2; border-color: #fecaca; }
+.duel-history-draw { background: #fffbeb; border-color: #fde68a; }
+
+.duel-history-icon { font-size: 1.4rem; }
+
+.duel-history-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.duel-history-opponent {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: 0.95rem;
+}
+
+.duel-history-date {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.duel-history-score {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #1e293b;
+}
+
+.duel-history-sep { color: #cbd5e1; font-weight: 400; }
+
+.duel-history-badge {
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.duel-history-badge-win  { background: #dcfce7; color: #15803d; }
+.duel-history-badge-loss { background: #fee2e2; color: #b91c1c; }
+.duel-history-badge-draw { background: #fef9c3; color: #a16207; }

--- a/web/src/navigation/AuthNavigator.tsx
+++ b/web/src/navigation/AuthNavigator.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import ProtectedRoute from "@shared/components/ProtectedRoute.component";
 import RedirectScreen from "@features/auth/pages/Redirect.page";
+import { DuelProvider } from "@features/duels/context/DuelContext";
+import ChallengeNotification from "@features/duels/components/ChallengeNotification";
 
 // Pages communes
 import HomeScreen from "@features/home/pages/Home.page";
@@ -37,6 +39,8 @@ import SubscriptionPage from "@features/parent/pages/Subscription.page";
 
 const AuthNavigator: React.FC = () => {
 	return (
+		<DuelProvider>
+			<ChallengeNotification />
 		<Routes>
 			{/* ==================== PAGE DE REDIRECTION ==================== */}
 
@@ -244,6 +248,7 @@ const AuthNavigator: React.FC = () => {
 
 			<Route path="*" element={<Navigate to="/" replace />} />
 		</Routes>
+		</DuelProvider>
 	);
 };
 

--- a/web/src/shared/types/duels.ts
+++ b/web/src/shared/types/duels.ts
@@ -18,3 +18,62 @@ export interface Duel {
     opponent: number;
   };
 }
+
+export type DuelScreen = 'lobby' | 'waiting' | 'game' | 'end';
+
+export interface DuelQuestion {
+  number: number;
+  question: string;
+  choices: string[];
+  time_limit: number;
+}
+
+export interface DuelScores {
+  [key: number]: number;
+}
+
+export interface DuelLastResult {
+  good_answer: number;
+  my_answer: number | null;
+  scores: DuelScores;
+}
+
+export interface DuelEndData {
+  scores: DuelScores;
+  winner: number | null;
+}
+
+export interface PendingChallenge {
+  challenge_id: string;
+  from_username: string;
+  expires_in: number;
+}
+
+export interface DuelHistoryEntry {
+  duel_id: number;
+  opponent_id: number;
+  opponent_username: string;
+  my_score: number;
+  opponent_score: number;
+  outcome: 'win' | 'loss' | 'draw';
+  played_at: string | null;
+}
+
+export interface DuelOpponentStats {
+  opponent_id: number;
+  opponent_username: string;
+  wins: number;
+  draws: number;
+  losses: number;
+  winrate: number;
+}
+
+export interface DuelStatsData {
+  total_games: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  winrate: number;
+  avg_score: number;
+  per_opponent: DuelOpponentStats[];
+}


### PR DESCRIPTION
- Updated `useDuelsPage` hook to fetch friends, duel history, and stats from the API.
- Implemented presence polling for friends' online status.
- Enhanced `DuelsScreen` to handle different game states (waiting, game, end) and display relevant components.
- Added `DuelStats` and `DuelHistory` components to show user statistics and match history.
- Introduced `LobbyToast` for displaying challenge notifications.
- Updated styles in `DuelsScreen.css` for new components and improved UI.
- Added new types in `duels.ts` for better type safety and clarity in duel-related data structures.
- Wrapped the application in `DuelProvider` to manage duel context and state globally.